### PR TITLE
Use test database for dev - DO NOT MERGE

### DIFF
--- a/smk-config.json
+++ b/smk-config.json
@@ -25,7 +25,7 @@
             "title": "BC Assessment Jurisdictions",
             "isVisible": true,
             "isQueryable": true,
-            "serviceUrl": "https://arcgis.bcassessment.ca/ext_wa/rest/services/BCGOV/BCA_JUR_SVT/MapServer/0",
+            "serviceUrl": "https://arcgis-test.bcassessment.ca/ext_test_wa/rest/services/BCGOV/BCA_JUR_SVT_TEST/MapServer/0",
             "opacity": 0.65,
             "scaleMin": null,
             "scaleMax": null,


### PR DESCRIPTION
The client has asked us to use their test database service in the dev environment (only). Please do not close the PR for this change as it may deploy to prod with the test database used instead of the prod database.